### PR TITLE
feat: add `--modern-no-syntax` flag to disable syntax highlight

### DIFF
--- a/pytest_modern/plugin.py
+++ b/pytest_modern/plugin.py
@@ -23,6 +23,12 @@ def pytest_addoption(parser: Parser):
         default=False,
         help="Disable color output",
     )
+    group.addoption(
+        "--modern-no-syntax",
+        action="store_true",
+        default=False,
+        help="Disable syntax highlighting",
+    )
     with suppress(ImportError):
         import pytest_rerunfailures as _  # noqa: F401
 

--- a/pytest_modern/terminal.py
+++ b/pytest_modern/terminal.py
@@ -257,7 +257,11 @@ class ModernTerminalReporter:
                 )
             else:
                 assert isinstance(report.longrepr, ExceptionChainRepr)
-                tb = ModernExceptionChainRepr(report.nodeid, report.longrepr)
+                tb = ModernExceptionChainRepr(
+                    report.nodeid,
+                    report.longrepr,
+                    no_syntax=self.no_syntax,
+                )
                 self.console.print(tb)
 
     def pytest_runtest_logfinish(
@@ -312,7 +316,9 @@ class ModernTerminalReporter:
                         failed_report.longrepr.reprcrash.message.splitlines()[0]
                     )  # type: ignore
                     crash_message = rich.syntax.Syntax(
-                        crash_message, "python", theme="ansi_dark"
+                        crash_message,
+                        "python" if not self.no_syntax else "text",
+                        theme="ansi_dark",
                     ).highlight(crash_message)
                     crash_message.rstrip()
                 except Exception:
@@ -337,7 +343,9 @@ class ModernTerminalReporter:
             test_report = self.test_reports[warning_report.nodeid]
             duration = pad_duration(test_report.duration)
             warn_message = rich.syntax.Syntax(
-                repr(warning_report.message.message), "python", theme="ansi_dark"
+                repr(warning_report.message.message),
+                "python" if not self.no_syntax else "text",
+                theme="ansi_dark",
             ).highlight(repr(warning_report.message.message))
             warn_message.rstrip()
             self.console.print(
@@ -352,6 +360,10 @@ class ModernTerminalReporter:
     @property
     def no_summary(self) -> bool:
         return self.config.getoption("no_summary")  # type: ignore
+
+    @property
+    def no_syntax(self) -> bool:
+        return self.config.getoption("modern_no_syntax")  # type: ignore
 
 
 def plurals(items: Collection | int) -> str:


### PR DESCRIPTION
Sometimes it is necessary to reduce too many colors, so you can enable the `--modern-no-syntax` flag

<img width="1256" height="560" alt="image" src="https://github.com/user-attachments/assets/94cdfc17-5e8a-4d90-a6d2-12454d3872d5" />
