### PR TITLE
refactor(config): use pytest's native color and highlight options

### DIFF
--- a/pytest_modern/plugin.py
+++ b/pytest_modern/plugin.py
@@ -17,18 +17,6 @@ def pytest_addoption(parser: Parser):
         default=False,
         help="Disable pytest-modern",
     )
-    group.addoption(
-        "--modern-no-color",
-        action="store_true",
-        default=False,
-        help="Disable color output",
-    )
-    group.addoption(
-        "--modern-no-syntax",
-        action="store_true",
-        default=False,
-        help="Disable syntax highlighting",
-    )
     with suppress(ImportError):
         import pytest_rerunfailures as _  # noqa: F401
 
@@ -57,8 +45,6 @@ def pytest_configure(config: Config) -> None:
                 config.option.only_rerun = only_rerun
 
         standard_reporter: Any = config.pluginmanager.getplugin("terminalreporter")
-        modern_reporter = ModernTerminalReporter(
-            standard_reporter.config, color=not config.getoption("modern_no_color")
-        )
+        modern_reporter = ModernTerminalReporter(standard_reporter.config)
         config.pluginmanager.unregister(standard_reporter)
         config.pluginmanager.register(modern_reporter, "terminalreporter")

--- a/pytest_modern/terminal.py
+++ b/pytest_modern/terminal.py
@@ -76,7 +76,6 @@ class ModernTerminalReporter:
     def __init__(
         self,
         config: pytest.Config,
-        color: bool,
         console: rich.console.Console | None = None,
     ):
         self.config = config
@@ -84,7 +83,7 @@ class ModernTerminalReporter:
             highlight=False,
             force_terminal=True,
             width=None if sys.stdout.isatty() else 200,
-            color_system="auto" if color else None,
+            color_system="auto" if not self.no_color else None,
         )
         self.console.file = trim_io_space(self.console.file)
 
@@ -386,16 +385,20 @@ class ModernTerminalReporter:
         return True
 
     @property
+    def no_color(self) -> bool:
+        return self.config.getoption("color") == "no"
+
+    @property
     def no_header(self) -> bool:
         return self.config.getoption("no_header")  # type: ignore
 
     @property
     def no_summary(self) -> bool:
-        return self.config.getoption("no_summary")  # type: ignore
+        return self.config.getoption(name="no_summary")  # type: ignore
 
     @property
     def no_syntax(self) -> bool:
-        return self.config.getoption("modern_no_syntax")  # type: ignore
+        return self.config.getoption("code_highlight") == "no"  # type: ignore
 
 
 def plurals(items: Collection | int) -> str:


### PR DESCRIPTION
Removes the custom `--modern-no-color` and `--modern-no-syntax` command-line options.

The plugin now respects the built-in `--color` and `--code-highlight` options from pytest to control terminal output, providing a cleaner and more standard user experience.