### PR TITLE
Escape node ids before rendering them as Rich markup

### DIFF
--- a/pytest_modern/terminal.py
+++ b/pytest_modern/terminal.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import pytest
 import rich.console
 import rich.live
+import rich.markup
 import rich.padding
 import rich.panel
 import rich.rule
@@ -135,7 +136,7 @@ class ModernTerminalReporter:
         self.total_items_collected += len(items)
 
         self.collect_live.update(
-            f"[green bold]Collecting[/] [magenta]{report.nodeid}[/magenta] ([bold]{self.total_items_collected}[/] total item{plurals(self.total_items_collected)})",
+            f"[green bold]Collecting[/] [magenta]{rich.markup.escape(report.nodeid)}[/magenta] ([bold]{self.total_items_collected}[/] total item{plurals(self.total_items_collected)})",
         )
         self.collect_live.refresh()
 
@@ -190,7 +191,9 @@ class ModernTerminalReporter:
             for child in tree.children:
                 self.console.print(child)
         for nodeid, collect_error in self.collect_errors.items():
-            self.console.print(f"[red bold]COLLECT ERROR >> {nodeid}[/]")
+            self.console.print(
+                f"[red bold]COLLECT ERROR >> {rich.markup.escape(nodeid)}[/]"
+            )
             self.console.print(collect_error)
 
     def pytest_runtest_logstart(
@@ -397,7 +400,7 @@ class ModernTerminalReporter:
                     duration = format_node_duration(failed_report.duration)
                     yield rich.text.Text.assemble(
                         rich.text.Text.from_markup(
-                            f"[red bold]{'FAIL':>10s}[/] [{duration:>10s}] [red bold]{failed_report.nodeid}[/]"
+                            f"[red bold]{'FAIL':>10s}[/] [{duration:>10s}] [red bold]{rich.markup.escape(failed_report.nodeid)}[/]"
                         ),
                         " ",
                         crash_message,
@@ -406,7 +409,7 @@ class ModernTerminalReporter:
                     item = self.items[failed_report.nodeid]
                     timeout = pad_duration(get_timeout(item), ">")
                     yield (
-                        f"[red bold]{'TIMEOUT':>10s}[/] [{timeout}] [red bold]{failed_report.nodeid}[/]"
+                        f"[red bold]{'TIMEOUT':>10s}[/] [{timeout}] [red bold]{rich.markup.escape(failed_report.nodeid)}[/]"
                     )
 
         for warning_report in self.categorized_reports.get("warning", []):
@@ -423,7 +426,7 @@ class ModernTerminalReporter:
             warn_message.rstrip()
             yield rich.text.Text.assemble(
                 rich.text.Text.from_markup(
-                    f"[yellow bold]{'WARN':>10s}[/] [{duration}] [yellow bold]{warning_report.nodeid}[/]"
+                    f"[yellow bold]{'WARN':>10s}[/] [{duration}] [yellow bold]{rich.markup.escape(warning_report.nodeid)}[/]"
                 ),
                 " ",
                 warn_message,

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -79,3 +79,8 @@ class TestGroup:
     def test_fail(self):
         a = 1
         assert a == 2
+
+
+@pytest.mark.parametrize("store", ["default_db", "redis_celery"])
+def test_parametrized_id(store):
+    raise RuntimeError(f"boom: {store}")


### PR DESCRIPTION
## Problem

Test node ids are interpolated into Rich console-markup strings in the collection lines and the `FAIL` / `TIMEOUT` / `WARN` summary lines. A **parametrized** node id ends in a bracketed suffix (e.g. `test_foo[default_db-stay]`), and `[...]` is valid Rich tag syntax — so Rich parses the suffix as a (meaningless) style tag and strips it from the rendered output.

The result: the summary shows the bare `test_foo` repeated once per case, with no way to tell the parameters apart:

```
   Summary [   125us] 2 tests run: 2 failed
      FAIL [    70us] test_demo.py::test_parametrized_id RuntimeError: boom: default_db
      FAIL [    54us] test_demo.py::test_parametrized_id RuntimeError: boom: redis_celery
```

Minimal repro of the underlying cause:

```python
import rich.text
rich.text.Text.from_markup('test_foo[default_db-stay]').plain
# -> 'test_foo'   (the [..] suffix is gone)
```

## Fix

Wrap the node id in `rich.markup.escape(...)` at each markup site (the `Collecting` line, the `COLLECT ERROR` line, and the `FAIL` / `TIMEOUT` / `WARN` summary lines) so the brackets render literally:

```
   Summary [   158us] 2 tests run: 2 failed
      FAIL [    94us] test_demo.py::test_parametrized_id[default_db] RuntimeError: boom: default_db
      FAIL [    64us] test_demo.py::test_parametrized_id[redis_celery] RuntimeError: boom: redis_celery
```

The live per-test status line (`new_test_status`) already builds the id with `Text.assemble` literal spans rather than markup, so it was already correct and is left unchanged.

## Test

Added a parametrized failing case to `tests/test_example.py` so the rendered summary visibly carries the `[param]` suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)